### PR TITLE
Add a unique id to each request

### DIFF
--- a/search_process.py
+++ b/search_process.py
@@ -18,4 +18,4 @@ def mapping_lookup_process(in_q, out_q, index_dir, num_shards, shard):
         t0 = monotonic()
         ret = ms.search(req)
         print("search proc: ", ret)
-        out_q.put((ret, "%.3fms" % ((monotonic() - t0) * 1000)))
+        out_q.put((ret, "%.3fms" % ((monotonic() - t0) * 1000), req["id"]))


### PR DESCRIPTION
Under high load, it is possible that thread A enqueues a request before thread B to the same shard worker within a very short interval of time. Both threads go to sleep blocking on results. The result arrive in the response queue in order but thread B wakes up before thread A and receives the response meant for A.

To naively fix the issue enqueue a unique id for each request, and the worker returns the unique id along with the response. The request process retries multiple times to find the response with the correct id in the queue.